### PR TITLE
[bootbox] Add default null value for backdrop

### DIFF
--- a/types/bootbox/index.d.ts
+++ b/types/bootbox/index.d.ts
@@ -6,7 +6,7 @@ interface BootboxBaseOptions<T = any> {
     callback?: ((result: T) => any) | undefined;
     onEscape?: (() => any) | boolean | undefined;
     show?: boolean | undefined;
-    backdrop?: boolean | undefined;
+    backdrop?: null | boolean | undefined;
     closeButton?: boolean | undefined;
     animate?: boolean | undefined;
     className?: string | undefined;


### PR DESCRIPTION
Null is the default value for backdrop: https://bootboxjs.com/documentation.html#option-backdrop (although internally it is "static", but null does the same)

You may want to set it as default if you set it to true or false with setDefaults(), and later want to use the default behavior.